### PR TITLE
Zig v0.10.0 support

### DIFF
--- a/example/simple.zig
+++ b/example/simple.zig
@@ -68,5 +68,5 @@ pub fn main() anyerror!void {
 
 fn run_sub2(args: []const []const u8) anyerror!void {
     var ip = ip_option.value.string.?;
-    std.log.debug("running sub2: ip={s}, bool={}, float={} arg_count={}", .{ ip, bool_option.value.bool, float_option.value.float, args.len });
+    std.log.debug("running sub2: ip={s}, bool={any}, float={any} arg_count={any}", .{ ip, bool_option.value.bool, float_option.value.float, args.len });
 }

--- a/src/command.zig
+++ b/src/command.zig
@@ -11,7 +11,7 @@ pub const Command = struct {
     action: ?Action = null,
 };
 
-pub const Action = fn (args: []const []const u8) anyerror!void;
+pub const Action = *const fn (args: []const []const u8) anyerror!void;
 
 pub const OptionValue = union(enum) {
     bool: bool,

--- a/src/iterators.zig
+++ b/src/iterators.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const ArgIterator = std.process.ArgIterator;
 
 pub const StringSliceIterator = struct {
     items: []const []const u8,
@@ -11,19 +10,6 @@ pub const StringSliceIterator = struct {
 
         if (self.index < self.items.len) {
             return self.items[self.index];
-        } else {
-            return null;
-        }
-    }
-};
-
-pub const SystemArgIterator = struct {
-    iter: *ArgIterator,
-    alloc: Allocator,
-
-    pub fn next(self: *SystemArgIterator) ?[]const u8 {
-        if (self.iter.next(self.alloc)) |arg| {
-            return arg catch unreachable;
         } else {
             return null;
         }

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -13,17 +13,13 @@ pub const ParseResult = struct {
 };
 
 pub fn run(cmd: *const command.Command, alloc: Allocator) anyerror!void {
-    var iter = std.process.args();
-    var it = iterators.SystemArgIterator{
-        .iter = &iter,
-        .alloc = alloc,
-    };
+    var iter = try std.process.argsWithAllocator(alloc);
+    defer iter.deinit();
 
-    var cr = try Parser(iterators.SystemArgIterator).init(cmd, it, alloc);
+    var cr = try Parser(std.process.ArgIterator).init(cmd, iter, alloc);
+    defer cr.deinit();
+
     var result = try cr.parse();
-    cr.deinit();
-    iter.deinit();
-
     return result.action(result.args);
 }
 


### PR DESCRIPTION
Hey! First, thanks for maintaining this library - using it has been a joy.

Zig 0.10.0 was released today, and has a few breaking changes that affect zig-cli:

- Function types have to be declared as constant pointers.
- The empty formatting directive `{}` is no longer allowed.
- The `std.process.ArgIterator` signature has changed to... exactly what your `iterators.SystemArgIterator` was. I removed `iterators.SystemArgIterator` and just pass `std.process.ArgIterator` directly into `Parser`.

These changes make it compile and pass the tests (and work in real usage for my project). One thing you might want to do is reconsider how the command line args system works since iterators.zig now just has one iterator defined. I didn't want to try make those kind of decisions and kept the changes as minimal as possible.

Of course, if you'd rather work in 0.10.0 support on your own, feel free to close this. Thanks again!