### PR TITLE
Add module for package manager support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,11 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
+    _ = b.addModule("zig-cli", .{
+        .source_file = std.Build.FileSource.relative("src/main.zig"),
+        .dependencies = &[_]std.Build.ModuleDependency{},
+    });
+
     const lib = b.addStaticLibrary(.{
         .name = "zig-cli",
         .root_source_file = .{ .path = "src/main.zig" },


### PR DESCRIPTION
I noticed that the library couldn't be imported using Zig's native package manager system, so I added this. 
Now it can be imported with:

#### build.zig.zon
```zig
.{
    .name = "example_app",
    .version = "0.0.0",
    .dependencies = .{
        .@"zig-cli" = .{
            .url = "https://github.com/typio/zig-cli/archive/refs/heads/main.tar.gz",
            .hash = "12209d0b011565e97264d37d07e41f7483e632aba0d0c0c74353be99e4dd08c336b7",
        },
    },
}
```

#### build.zig
```zig
pub fn build(b: *std.Build) void {
  const exe = b.addExecutable(.{
      ...
  });
  
  const zig_cli_module = b.dependency("zig-cli", .{}).module("zig-cli");
  exe.addModule("zig-cli", zig_cli_module);
  
  b.installArtifact(exe);
}
```

Thank you!