### PR TITLE
new zig update: use `const` instead of `var` when possible

### DIFF
--- a/src/help.zig
+++ b/src/help.zig
@@ -43,7 +43,7 @@ const HelpPrinter = struct {
         for (command_path) |cmd| {
             self.printer.format("{s} ", .{cmd.name});
         }
-        var current_command = command_path[command_path.len - 1];
+        const current_command = command_path[command_path.len - 1];
         self.printer.format("[OPTIONS]\n", .{});
         self.printer.printColor(color_clear);
 
@@ -81,7 +81,7 @@ const HelpPrinter = struct {
         if (current_command.options) |option_list| {
             var max_option_width: usize = 0;
             for (option_list) |option| {
-                var w = option.long_name.len + option.value_name.len + 3;
+                const w = option.long_name.len + option.value_name.len + 3;
                 max_option_width = @max(max_option_width, w);
             }
             option_column_width = max_option_width + 3;

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -100,7 +100,7 @@ pub fn Parser(comptime Iterator: type) type {
             }
 
             self.ensure_all_required_set(self.current_command());
-            var args = try self.captured_arguments.toOwnedSlice();
+            const args = try self.captured_arguments.toOwnedSlice();
 
             if (self.current_command().action) |action| {
                 return ParseResult{ .action = action, .args = args };

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -26,12 +26,12 @@ const StringSliceIterator = struct {
 };
 
 fn run(app: *command.App, items: []const []const u8) !ParseResult {
-    var it = StringSliceIterator{
+    const it = StringSliceIterator{
         .items = items,
     };
 
     var parser = try Parser(StringSliceIterator).init(app, it, alloc);
-    var result = try parser.parse();
+    const result = try parser.parse();
     parser.deinit();
     return result;
 }
@@ -230,7 +230,7 @@ test "mix positional arguments and options" {
         .action = dummy_action,
     };
 
-    var result = try run(&app, &.{ "cmd", "--bb", "tt", "arg1", "-a", "val", "arg2", "--", "--arg3", "-arg4" });
+    const result = try run(&app, &.{ "cmd", "--bb", "tt", "arg1", "-a", "val", "arg2", "--", "--arg3", "-arg4" });
     defer std.testing.allocator.free(result.args);
     try std.testing.expectEqualStrings("val", aav);
     try std.testing.expectEqualStrings("tt", bbv);

--- a/src/value_ref.zig
+++ b/src/value_ref.zig
@@ -21,7 +21,7 @@ pub const ValueRef = struct {
                 if (list.list_ptr == null) {
                     list.list_ptr = try list.vtable.createList(alloc);
                 }
-                var value_ptr = try list.vtable.addOne(list.list_ptr.?, alloc);
+                const value_ptr = try list.vtable.addOne(list.list_ptr.?, alloc);
                 try self.value_data.value_parser(value_ptr, value);
             },
         }
@@ -97,7 +97,7 @@ const ValueList = struct {
         const List = std.ArrayListUnmanaged(T);
         const gen = struct {
             fn createList(alloc: Allocator) anyerror!*anyopaque {
-                var list = try alloc.create(List);
+                const list = try alloc.create(List);
                 list.* = List{};
                 return list;
             }
@@ -107,7 +107,7 @@ const ValueList = struct {
             }
             fn finalize(list_ptr: *anyopaque, dest: *anyopaque, alloc: Allocator) anyerror!void {
                 const list: *List = @alignCast(@ptrCast(list_ptr));
-                var destSlice: *[]T = @alignCast(@ptrCast(dest));
+                const destSlice: *[]T = @alignCast(@ptrCast(dest));
                 destSlice.* = try list.toOwnedSlice(alloc);
                 alloc.destroy(list);
             }


### PR DESCRIPTION
This PR adds support for last Zig update by using `const` instead of `var` when possible.