### PR TITLE
Add build.zig to paths in build.zig.zon

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
 	.name = "zig-cli",
 	.version = "0.8.0",
-	.paths = .{"./src", "./build.zig.zon"},
+	.paths = .{"./src", "./build.zig", "./build.zig.zon"},
 }

--- a/examples/standalone/build.zig.zon
+++ b/examples/standalone/build.zig.zon
@@ -5,8 +5,8 @@
 	.dependencies = .{
 		.@"zig-cli" = .{
 			// URL pattern: https://github.com/sam701/zig-cli/archive/<commit hash>.tar.gz
-			.url = "https://github.com/sam701/zig-cli/archive/e32f7454d690761ec2b4eab8600e0610d0d233bd.tar.gz",
-			.hash = "1220bf895404724653daf8e0e054e6c943b8dc13c312c3d32d9e0eaa4448f261fd98",
+			.url = "https://github.com/sam701/zig-cli/archive/ddf49596a9225c91e6cd9c28904aec598d5becf0.tar.gz",
+			.hash = "1220249b6509b36d646a5d2c5da6dfd6fdde7328c67ed9e31eb4f0b30557972ca3e7",
 	    },
 	},
 }


### PR DESCRIPTION
Initially reported here: https://github.com/ziglang/zig/issues/18282

If `build.zig` is not included in `paths` in `build.zig.zon`, the resulting package will not have that file included, leading to the package not being usable as intended, as seen through `zig fetch --debug-hash`:

```
$ zig fetch --debug-hash https://github.com/sam701/zig-cli/archive/e32f7454d690761ec2b4eab8600e0610d0d233bd.tar.gz
file: 54b645cc4a56212c6b1f97187aa6a129fd2eaebb9d8bea7cef04eb018eb7e208: build.zig.zon
file: fa9b337869d6c96162c0b84bd6889b38f445cffee40b6a9a8ffe0c06dd047d45: src/Printer.zig
file: c21c93b35cbd4fe8f7c59414652fb81f4cc06f7e0e0733b84f187c77a8443ca0: src/arg.zig
file: 1658e9acfe148c710d2754e42ab3e8a61d262bd46b8ba51510cda3ae3c0b98b6: src/command.zig
file: abce9fc3079e47c86ef9e1b0628b7ceca170b838c60857b98aa45c92844a706a: src/help.zig
file: 44478322ab927d0a57d8c2f442b76dca6b86e817c117d89ee3cfea6479ac4a17: src/main.zig
file: af69f2c9bd7f83454ff2368e986ccd4bc176f12628c3f10ce1e3fc927b1867c1: src/parser.zig
file: 9160cfb9b9d3ee6454dbfe34662a6ae471aae02b6ad1401ed48e40165b5a7c39: src/tests.zig
file: f0b90aebf22be930287b872faebf948494c34c7f1cb5bfcf51b962a9143a04c3: src/value_parser.zig
file: b6972db0a57450f4b70e4eeaa375ef683c6272b268bd8740b61062d40038eefe: src/value_ref.zig
12205d064a9bd4dac1ebce2cead5bc686ee85eb703b994495efd3b65115666555cd7
```

To fix this, I added `build.zig` to the `paths` field, and also updated the standalone example to point to this new version (which runs successfully for me on `0.12.0-dev.1828+225fe6ddb`).

If this PR is merged using a merge commit, the update to the example's `build.zig.zon` should still be valid; otherwise (if any changes are made, e.g. using a squash commit or rebase), it will have to be updated again to reflect the final commit hash.