### PR TITLE
Print help on errors

### DIFF
--- a/src/app_runner.zig
+++ b/src/app_runner.zig
@@ -50,8 +50,7 @@ pub const AppRunner = struct {
         return self.allocSlice(command.Command, args);
     }
 
-    pub const ArgumentError = error.ArgumentError;
-    pub const Error = Allocator.Error || error{ArgumentError};
+    pub const Error = Allocator.Error;
 
     /// `getAction` returns the action function that should be called by the main app.
     pub fn getAction(self: *Self, app: *const App) Error!command.ExecFn {

--- a/src/command.zig
+++ b/src/command.zig
@@ -35,6 +35,9 @@ pub const HelpConfig = struct {
     color_option: []const u8 = "32",
     /// Color for error messages in help.
     color_error: []const u8 = "31;1",
+
+    /// Whether to print last command help on errors like missing arguments or options.
+    print_help_on_error: bool = true,
 };
 
 /// Structure representing a command.


### PR DESCRIPTION
* Print help message for the last command where the error occurred.
* This behaviour is by default on, but can be turned off by setting `app.help_config.print_help_on_error = false`

Close #53 