### PR TITLE
Added missing error_data to boolean option parsing

### DIFF
--- a/src/parser.zig
+++ b/src/parser.zig
@@ -351,6 +351,7 @@ pub fn Parser(comptime Iterator: type) type {
                 if (opt.value_ref.value_data.is_bool) {
                     opt.value_ref.put(str_true, self.orig_allocator) catch unreachable;
                 } else {
+                    self.error_data = ErrorData{ .entity_name = opt.value_name };
                     return error.MissingOptionValue;
                 }
             }


### PR DESCRIPTION
This issue can be reproduced by running the "simple" example as follows:  simple sub1 -ib
Previously, this would cause a panic (unreachable) on the line below because cr.error_data was not set.
            processError(err, cr.error_data orelse unreachable, app);