### PR TITLE
Chore/upgrade to zig 0.15.1

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.14.1
+          version: 0.15.1
       - run: zig fmt --check *.zig src/*.zig
       - run: zig build
       - run: zig build test
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.14.1
+          version: 0.15.1
       - run: zig build
       - run: zig build test
 

--- a/build.zig
+++ b/build.zig
@@ -18,29 +18,34 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(lib);
 
     const main_tests = b.addTest(.{
-        .root_source_file = b.path("src/tests.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     const run_tests = b.addRunArtifact(main_tests);
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&run_tests.step);
 
     const simple = b.addExecutable(.{
-        .target = target,
         .name = "simple",
-        .root_source_file = b.path("examples/simple.zig"),
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .root_source_file = b.path("examples/simple.zig"),
+            .optimize = optimize,
+        }),
     });
     simple.root_module.addImport("cli", lib_mod);
     b.installArtifact(simple);
     b.default_step.dependOn(&simple.step);
 
     const short = b.addExecutable(.{
-        .target = target,
         .name = "short",
-        .root_source_file = b.path("examples/short.zig"),
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .root_source_file = b.path("examples/short.zig"),
+            .optimize = optimize,
+        }),
     });
     short.root_module.addImport("cli", lib_mod);
     b.installArtifact(short);

--- a/src/app_runner.zig
+++ b/src/app_runner.zig
@@ -66,7 +66,10 @@ pub const AppRunner = struct {
         } else |err| {
             processError(err, cr.error_data orelse unreachable, app);
             if (app.help_config.print_help_on_error) {
-                _ = std.io.getStdOut().write("\n") catch unreachable;
+                var stdout = std.fs.File.stdout().writerStreaming(&.{});
+                const writer = &stdout.interface;
+
+                _ = writer.write("\n") catch unreachable;
                 try help.print_command_help(app, try cr.command_path.toOwnedSlice(), cr.global_options);
             }
             std.posix.exit(1);
@@ -117,7 +120,7 @@ fn processError(err: parser.ParseError, err_data: parser.ErrorData, app: *const 
 }
 
 pub fn printError(app: *const App, comptime fmt: []const u8, args: anytype) void {
-    var p = Printer.init(std.io.getStdErr(), app.help_config.color_usage);
+    var p = Printer.init(std.fs.File.stderr(), app.help_config.color_usage);
 
     p.printInColor(app.help_config.color_error, "ERROR");
     p.format(": ", .{});

--- a/src/help.zig
+++ b/src/help.zig
@@ -14,7 +14,7 @@ pub fn print_command_help(
     command_path: []const *const command.Command,
     global_options: *const GlobalOptions,
 ) !void {
-    const stdout = std.io.getStdOut();
+    const stdout = std.fs.File.stdout();
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     const allocator = gpa.allocator();
     var arena = std.heap.ArenaAllocator.init(allocator);

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -53,7 +53,7 @@ pub fn Parser(comptime Iterator: type) type {
         arena: ArenaAllocator,
         arg_iterator: Iterator,
         app: *const command.App,
-        command_path: std.ArrayList(*const command.Command),
+        command_path: std.array_list.Managed(*const command.Command),
         position_argument_ix: usize = 0,
         next_arg: ?[]const u8 = null,
         global_options: *GlobalOptions,
@@ -65,7 +65,7 @@ pub fn Parser(comptime Iterator: type) type {
                 .arena = ArenaAllocator.init(alloc),
                 .arg_iterator = it,
                 .app = app,
-                .command_path = try std.ArrayList(*const command.Command).initCapacity(alloc, 16),
+                .command_path = try std.array_list.Managed(*const command.Command).initCapacity(alloc, 16),
                 .global_options = try GlobalOptions.init(app.help_config.color_usage, alloc),
             };
         }


### PR DESCRIPTION
Upgrade for use with zig 0.15.1.

OS: ubuntu 24.04
Zig Version: 0.15.1
Arch: x86_64

Tested by running the following
1. zig build
2. `./zig-out/bin/simple sub1 --help` (see help text in stdout)
3. `./zig-out/bin/simple sub1` (see text in stderr)

The intention is to not change the behavior, instead keep the same behavior.