### PR TITLE
Added missing flush() on error exit

### DIFF
--- a/src/app_runner.zig
+++ b/src/app_runner.zig
@@ -83,6 +83,7 @@ pub const AppRunner = struct {
                     self.arena.allocator(),
                 );
             }
+            printer.flush();
             std.process.exit(1);
         }
     }


### PR DESCRIPTION
Fixes #74.

Printing the help text does a `defer printer.flush()`. When `print_help_on_error = false` no flush is performed before exit.
